### PR TITLE
add setting volume in decibel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,6 @@ pub use poll::PollDescriptors as PollDescriptors;
 
 pub mod mixer;
 pub use mixer::Mixer as Mixer;
-pub use mixer::AccuracyDirection as AccuracyDirection;
 
 mod io;
 pub use io::Output;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ pub use poll::PollDescriptors as PollDescriptors;
 
 pub mod mixer;
 pub use mixer::Mixer as Mixer;
+pub use mixer::AccuracyDirection as AccuracyDirection;
 
 mod io;
 pub use io::Output;

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -3,9 +3,10 @@
 use std::ffi::{CStr, CString};
 use std::{ptr, mem, fmt};
 use std::ops::Deref;
-use libc::{c_long};
+use libc::{c_long, c_int};
 
 use alsa;
+use super::ValueOr;
 use super::error::*;
 
 const SELEM_ID_SIZE: usize = 64;
@@ -162,22 +163,6 @@ impl SelemId {
 
 }
 
-pub enum AccuracyDirection {
-    AccurateOrFirstBelow,
-    Accurate,
-    AccurateOrFirstAbove
-}
-
-impl AccuracyDirection {
-    pub fn to_i(&self) -> i32 {
-        match *self {
-            AccuracyDirection::AccurateOrFirstAbove => -1,
-            AccuracyDirection::Accurate => 0,
-            AccuracyDirection::AccurateOrFirstBelow => 1,
-        }
-    }
-}
-
 /// Wraps an Elem as a Selem
 // #[derive(Copy, Clone)]
 pub struct Selem<'a>(Elem<'a>);
@@ -318,8 +303,8 @@ impl<'a> Selem<'a> {
         acheck!(snd_mixer_selem_set_playback_volume(self.handle, channel as i32, value as c_long)).map(|_| ())
     }
 
-    pub fn set_playback_volume_decibel(&self, channel: SelemChannelId, value: i64, dir: AccuracyDirection) -> Result<()> {
-        acheck!(snd_mixer_selem_set_playback_dB(self.handle, channel as i32, value as c_long, dir.to_i())).map(|_| ())
+    pub fn set_playback_db(&self, channel: SelemChannelId, value: mb, dir: ValueOr) -> Result<()> {
+        acheck!(snd_mixer_selem_set_playback_dB(self.handle, channel as i32, *value as c_long, dir as c_int)).map(|_| ())
     }
 
     pub fn set_capture_volume(&self, channel: SelemChannelId, value: i64) -> Result<()> {

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -162,6 +162,22 @@ impl SelemId {
 
 }
 
+pub enum AccuracyDirection {
+    AccurateOrFirstBelow,
+    Accurate,
+    AccurateOrFirstAbove
+}
+
+impl AccuracyDirection {
+    pub fn to_i(&self) -> i32 {
+        match *self {
+            AccuracyDirection::AccurateOrFirstAbove => -1,
+            AccuracyDirection::Accurate => 0,
+            AccuracyDirection::AccurateOrFirstBelow => 1,
+        }
+    }
+}
+
 /// Wraps an Elem as a Selem
 // #[derive(Copy, Clone)]
 pub struct Selem<'a>(Elem<'a>);
@@ -300,6 +316,10 @@ impl<'a> Selem<'a> {
 
     pub fn set_playback_volume(&self, channel: SelemChannelId, value: i64) -> Result<()> {
         acheck!(snd_mixer_selem_set_playback_volume(self.handle, channel as i32, value as c_long)).map(|_| ())
+    }
+
+    pub fn set_playback_volume_decibel(&self, channel: SelemChannelId, value: i64, dir: AccuracyDirection) -> Result<()> {
+        acheck!(snd_mixer_selem_set_playback_dB(self.handle, channel as i32, value as c_long, dir.to_i())).map(|_| ())
     }
 
     pub fn set_capture_volume(&self, channel: SelemChannelId, value: i64) -> Result<()> {


### PR DESCRIPTION
I've added [snd_mixer_selem_set_playback_dB](http://www.alsa-project.org/alsa-doc/alsa-lib/group___simple_mixer.html#ga8bfb52575e4bb06deb30799bc39c0768)

This function uses `dir` to `select direction (-1 = accurate or first bellow, 0 = accurate, 1 = accurate or first above)`. I've added an enum for this called `AccuracyDirection` but there is also a `ValueOr` enum in `lib.rs`. Should I use ValueOr for this function too?