### PR TITLE
Silence note on Noteon event with 0 velocity.

### DIFF
--- a/synth-example/src/main.rs
+++ b/synth-example/src/main.rs
@@ -214,7 +214,11 @@ fn read_midi_event(input: &mut seq::Input, synth: &mut Synth) -> Result<bool, Bo
     match ev.get_type() {
         seq::EventType::Noteon => {
             let data: seq::EvNote = ev.get_data().unwrap();
-            synth.add_note(data.note, f64::from(data.velocity + 64) / 2048.0);
+            if data.velocity == 0 {
+                synth.remove_note(data.note);
+            } else {
+                synth.add_note(data.note, f64::from(data.velocity + 64) / 2048.0);
+            }
         },
         seq::EventType::Noteoff => {
             let data: seq::EvNote = ev.get_data().unwrap();


### PR DESCRIPTION
My Miditech MIDI controller sends Noteon events with the velocity set to
0 instead of sending the Noteoff event. This change makes the synth
behave as expected.