### PR TITLE
Add a constructor with &str argument for HintIter

### DIFF
--- a/src/device_name.rs
+++ b/src/device_name.rs
@@ -36,6 +36,11 @@ impl HintIter {
         acheck!(snd_device_name_hint(cnr, iface.as_ptr(), &mut p))
             .map(|_| HintIter(p, 0))
     }
+
+    /// A constructor variant that takes the interface as a Rust string slice.
+    pub fn from_str_iface(card: Option<&Card>, iface: &str) -> Result<HintIter> {
+        HintIter::new(card, &CString::new(iface).unwrap())
+    }
 }
 
 impl Iterator for HintIter {

--- a/src/device_name.rs
+++ b/src/device_name.rs
@@ -38,7 +38,7 @@ impl HintIter {
     }
 
     /// A constructor variant that takes the interface as a Rust string slice.
-    pub fn from_str_iface(card: Option<&Card>, iface: &str) -> Result<HintIter> {
+    pub fn new_str(card: Option<&Card>, iface: &str) -> Result<HintIter> {
         HintIter::new(card, &CString::new(iface).unwrap())
     }
 }


### PR DESCRIPTION
Just a convenience thing. I hope temporarily creating a `CString` (and unwrapping it) just for a single function call is not against the lib's philosophy. 

I'm not particularly happy with the function's name, any suggestions?