### PR TITLE
Bump nix and libc to fix arm compilation issues 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,11 @@ categories = ["multimedia::audio", "api-bindings"]
 readme = "README.md"
 
 [dependencies]
-libc = "0.2.21"
+libc = "0.2.60"
 alsa-sys = "0.1.1"
 bitflags = "0.9"
-nix = "0.9"
+nix = "0.14.1"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "diwic/alsa-rs" }
 is-it-maintained-open-issues = { repository = "diwic/alsa-rs" }
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,7 +49,7 @@ pub fn from_code(func: &'static str, r: c_int) -> Result<c_int> {
 
 impl Error {
     pub fn new(func: &'static str, res: c_int) -> Error { 
-        let errno = nix::Errno::from_i32(res as i32);
+        let errno = nix::errno::Errno::from_i32(res as i32);
         Error(func, nix::Error::from_errno(errno))
     }
 
@@ -61,7 +61,7 @@ impl Error {
     pub fn func(&self) -> &'static str { self.0 }
 
     /// The errno, if any. 
-    pub fn errno(&self) -> Option<nix::Errno> { if let nix::Error::Sys(x) = self.1 { Some(x) } else { None } }
+    pub fn errno(&self) -> Option<nix::errno::Errno> { if let nix::Error::Sys(x) = self.1 { Some(x) } else { None } }
 
     /// Underlying error
     pub fn nix_error(&self) -> nix::Error { self.1 }
@@ -90,5 +90,5 @@ fn broken_pcm_name() {
     use std::ffi::CString;
     let e = ::PCM::open(&*CString::new("this_PCM_does_not_exist").unwrap(), ::Direction::Playback, false).err().unwrap();
     assert_eq!(e.func(), "snd_pcm_open");
-    assert_eq!(e.errno().unwrap(), nix::Errno::ENOENT);
+    assert_eq!(e.errno().unwrap(), nix::errno::Errno::ENOENT);
 }

--- a/src/pcm_direct.rs
+++ b/src/pcm_direct.rs
@@ -80,8 +80,8 @@ pub struct snd_pcm_sync_ptr {
 	pub c: snd_pcm_mmap_control_r,
 }
 
-ioctl!(read sndrv_pcm_ioctl_channel_info with b'A', 0x32; snd_pcm_channel_info);
-ioctl!(readwrite sndrv_pcm_ioctl_sync_ptr with b'A', 0x23; snd_pcm_sync_ptr);
+ioctl_read!(sndrv_pcm_ioctl_channel_info, b'A', 0x32, snd_pcm_channel_info);
+ioctl_readwrite!(sndrv_pcm_ioctl_sync_ptr, b'A', 0x23, snd_pcm_sync_ptr);
 
 fn pagesize() -> usize {
     unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
@@ -115,7 +115,7 @@ impl SyncPtrStatus {
         }
 
         sndrv_pcm_ioctl_sync_ptr(fd, &mut data).map_err(|_|
-            Error::new("SNDRV_PCM_IOCTL_SYNC_PTR", nix::Errno::last() as i32))?;
+            Error::new("SNDRV_PCM_IOCTL_SYNC_PTR", nix::errno::Errno::last() as i32))?;
 
         let i = data.s.status.state;
         if (i >= (pcm::State::Open as snd_pcm_state_t)) && (i <= (pcm::State::Disconnected as snd_pcm_state_t)) {
@@ -278,7 +278,7 @@ impl<S> DriverMemory<S> {
         let flags = if writable { libc::PROT_WRITE | libc::PROT_READ } else { libc::PROT_READ };
         let p = unsafe { libc::mmap(ptr::null_mut(), total, flags, libc::MAP_FILE | libc::MAP_SHARED, fd, offs) };
         if p == ptr::null_mut() || p == libc::MAP_FAILED {
-            Err(Error::new("mmap (of driver memory)", nix::Errno::last() as i32))
+            Err(Error::new("mmap (of driver memory)", nix::errno::Errno::last() as i32))
         } else {
             Ok(DriverMemory { ptr: p as *mut S, size: total })
         }
@@ -314,7 +314,7 @@ impl<S> SampleData<S> {
         let info = unsafe {
             let mut info: snd_pcm_channel_info = mem::zeroed();
             sndrv_pcm_ioctl_channel_info(fd, &mut info).map_err(|_|
-                Error::new("SNDRV_PCM_IOCTL_CHANNEL_INFO", nix::Errno::last() as i32))?;
+                Error::new("SNDRV_PCM_IOCTL_CHANNEL_INFO", nix::errno::Errno::last() as i32))?;
             info
         };
         // println!("{:?}", info);
@@ -687,4 +687,3 @@ fn playback_to_plughw_mmap() {
     assert_eq!(m.appl_ptr(), m.buffer_size());
     assert!(m.hw_ptr() >= m.buffer_size());
 }
-


### PR DESCRIPTION
`PTRACE_GETFPXREGS` and `PTRACE_SETFPXREGS` were removed in https://github.com/rust-lang/libc/commit/d2695436ba5072078796c76f727a296e0f43caa6 and thus `nix` was failing to compile for arm targets if some other crate depended on `libc: ^0.2.55` and above. 

The fix for `nix` (https://github.com/nix-rust/nix/commit/196b05b5c7be39b73dcadca5457948d807fdf913) was backported but only down to `0.11` (https://github.com/nix-rust/nix/issues/1057) 

I have not yet run the test cases on this yet, currently on a windoze machine, will try doing them tomorrow. 

Do you foresee any issues?
