### PR TITLE
add handle_events to mixer api

### DIFF
--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -57,6 +57,9 @@ impl Mixer {
         }
     }
 
+    pub fn handle_events(&self) -> Result<u32> {
+        acheck!(snd_mixer_handle_events(self.0)).map(|x| x as u32)
+    }
 
     pub fn wait(&self, timeout_ms: Option<u32>) -> Result<bool> {
         acheck!(snd_mixer_wait(self.0, timeout_ms.map(|x| x as c_int).unwrap_or(-1))).map(|i| i == 1) }


### PR DESCRIPTION
I'm not sure about catching events api,
but anyway i guess functions like snd_mixer_handle_events and/or snd_hctl_handle_events should be wrapped even using poll.