### PR TITLE
rawmidi: Fix non-blocking open on input devices

### DIFF
--- a/src/rawmidi.rs
+++ b/src/rawmidi.rs
@@ -119,7 +119,7 @@ impl Rawmidi {
 
     pub fn open(name: &CStr, dir: Direction, nonblock: bool) -> Result<Rawmidi> {
         let mut h = ptr::null_mut();
-        let flags = if nonblock { 1 } else { 0 }; // FIXME: alsa::SND_RAWMIDI_NONBLOCK does not exist in alsa-sys
+        let flags = if nonblock { 2 } else { 0 }; // FIXME: alsa::SND_RAWMIDI_NONBLOCK does not exist in alsa-sys
         acheck!(snd_rawmidi_open(
             if dir == Direction::Capture { &mut h } else { ptr::null_mut() },
             if dir == Direction::Playback { &mut h } else { ptr::null_mut() },


### PR DESCRIPTION
Attempting to use non-blocking IO on an input device in rawmidi causes an assert in libasound:

midirust: rawmidi_hw.c:213: snd_rawmidi_hw_open: Assertion `outputp' failed.

This seems to be because we are passing SND_RAWMIDI_APPEND (1) instead of SND_RAWMIDI_NONBLOCK (2) into rawmidi_open and there is no output device.

This patch would be better if it had the proper constants in, of course, but this fixes it for the time-being.