### PR TITLE
Fix clippy warnings (deny by default)

### DIFF
--- a/src/device_name.rs
+++ b/src/device_name.rs
@@ -65,7 +65,8 @@ pub struct Hint {
 
 impl Hint {
     fn get_str(p: *const c_void, name: &str) -> Option<String> {
-        let c = unsafe { alsa::snd_device_name_get_hint(p, CString::new(name).unwrap().as_ptr()) };
+        let name = CString::new(name).unwrap();
+        let c = unsafe { alsa::snd_device_name_get_hint(p, name.as_ptr()) };
         from_alloc("snd_device_name_get_hint", c).ok()
     }
 

--- a/src/direct/pcm.rs
+++ b/src/direct/pcm.rs
@@ -549,7 +549,7 @@ fn record_from_plughw_rw() {
     assert_eq!(ss.state(), State::Running);
     assert!(ss.hw_ptr() >= 512);
     let t2 = ss.htstamp();
-    assert!(t2.tv_sec > 0 || t2.tv_sec > 0);
+    assert!(t2.tv_sec > 0 || t2.tv_nsec > 0);
 }
 
 


### PR DESCRIPTION
Just two things caught by clippy:
- [`clippy::eq_op`](https://rust-lang.github.io/rust-clippy/master/#eq_op)
- [`clippy::temporary_cstring_as_ptr`](https://rust-lang.github.io/rust-clippy/master/#temporary_cstring_as_ptr)