### PR TITLE
Re-export libc::pollfd

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -5,7 +5,7 @@
 use libc;
 use super::error::*;
 use std::io;
-use libc::pollfd;
+pub use libc::pollfd;
 
 
 bitflags! {


### PR DESCRIPTION
So library users don't have to put libc in their Cargo.toml in order to for example store pollfd's in a struct (or otherwise pass around pollfd's explicitly).