### PR TITLE
Update dependencies. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-libc = "0.2.81"
+libc = "0.2.65"
 alsa-sys = "0.3.0"
 bitflags = "1.2.1"
 nix = "0.19.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-libc = "0.2.65"
+libc = "0.2.81"
 alsa-sys = "0.3.0"
 bitflags = "1.2.1"
-nix = "0.15"
+nix = "0.19.1"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "diwic/alsa-rs" }

--- a/synth-example/Cargo.toml
+++ b/synth-example/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["David Henningsson <diwic@ubuntu.com>"]
 
 [dependencies]
 sample = "0.7"
-alsa = "0.4"
+alsa = { path = ".." }
 clap = "2.20"

--- a/synth-example/Cargo.toml
+++ b/synth-example/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["David Henningsson <diwic@ubuntu.com>"]
 
 [dependencies]
 sample = "0.7"
-alsa = { path = ".." }
+alsa = { path = "..", version = "0.4" }
 clap = "2.20"

--- a/synth-example/src/main.rs
+++ b/synth-example/src/main.rs
@@ -312,5 +312,5 @@ fn run() -> Res<()> {
 }
 
 fn main() {
-    if let Err(e) = run() { println!("Error ({}) {}", e.description(), e); }
+    if let Err(e) = run() { println!("Error ({})", e); }
 }


### PR DESCRIPTION
Also makes synth-example use the local alsa-rs, so you can easily test changes.

As for the error change, .description() is deprecated on Error.