### PR TITLE
update nix to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alsa"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["David Henningsson <diwic@ubuntu.com>"]
 
 description = "Thin but safe wrappers for ALSA (Linux sound API)"
@@ -16,7 +16,7 @@ edition = "2018"
 libc = "0.2.65"
 alsa-sys = "0.3.1"
 bitflags = "1.2.1"
-nix = "0.19"
+nix = "0.20"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "diwic/alsa-rs" }


### PR DESCRIPTION
Hi,

could you please update the nix version used, and also `cargo publish` to crates.io, as the nix version there is quite old (0.15).
Thank you