### PR TITLE
Update Cargo.toml to match root package version

### DIFF
--- a/synth-example/Cargo.toml
+++ b/synth-example/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["David Henningsson <diwic@ubuntu.com>"]
 
 [dependencies]
 sample = "0.7"
-alsa = { path = "..", version = "0.4" }
+alsa = { path = "..", version = "0.5" }


### PR DESCRIPTION
I've tried to run synth example locally, and it failed to resolve dependency.

```bash
pi@raspberrypi:~/projects/alsa-rs/synth-example $ cargo run 
    Updating crates.io index
error: failed to select a version for the requirement `alsa = "^0.4"`
candidate versions found which didn't match: 0.5.0
location searched: /home/pi/projects/alsa-rs
required by package `synth-example v0.1.0 (~/projects/alsa-rs/synth-example)`
```

Fixing it to `0.5` solves the problem (and introduces new one 😆)