### PR TITLE
Fix example synth

### DIFF
--- a/synth-example/Cargo.toml
+++ b/synth-example/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 dasp = { version = "0.11", features = ["signal"] }
-alsa = { path = "..", version = "0.5" }
+alsa = { path = "..", version = "0.6" }

--- a/synth-example/src/main.rs
+++ b/synth-example/src/main.rs
@@ -218,9 +218,7 @@ fn write_samples_io(p: &alsa::PCM, io: &mut alsa::pcm::IO<SF>, synth: &mut Synth
         Ok(n) => n,
         Err(e) => {
             println!("Recovering from {}", e);
-            if let Some(errno) = e.errno() {
-                p.recover(errno as std::os::raw::c_int, true)?;
-            }
+            p.recover(e.errno() as std::os::raw::c_int, true)?;
             p.avail_update()?
         }
     } as usize;


### PR DESCRIPTION
Hello!

I've noticed that after version `0.6` release the `synth-example` had `alsa-rs` pinned to version `0.5`. Fixed that along with a minor API change that broke the synth build.