### PR TITLE
Update nix to 0.24, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = ["README.md", "LICENSE-*", "Cargo.toml", "src/"]
 libc = "0.2.105"
 alsa-sys = "0.3.1"
 bitflags = "1.3.2"
-nix = "0.23"
+nix = { version = "0.24", default-features = false, features = ["ioctl"] }
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "diwic/alsa-rs" }


### PR DESCRIPTION
This reduces compile times and removes memoffset as an indirect dependency.