### PR TITLE
add set_playback_volume_range and set_capture_volume_range to Selem

### DIFF
--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -347,6 +347,10 @@ impl<'a> Selem<'a> {
         acheck!(snd_mixer_selem_set_playback_volume(self.handle, channel as i32, value as c_long)).map(|_| ())
     }
 
+    pub fn set_playback_volume_range(&self, min: i64, max: i64) -> Result<()> {
+        acheck!(snd_mixer_selem_set_playback_volume_range(self.handle, min as c_long, max as c_long)).map(|_| ())
+    }
+
     pub fn set_playback_volume_all(&self, value: i64) -> Result<()> {
         acheck!(snd_mixer_selem_set_playback_volume_all(self.handle, value as c_long)).map(|_| ())
     }
@@ -369,6 +373,10 @@ impl<'a> Selem<'a> {
 
     pub fn set_capture_volume(&self, channel: SelemChannelId, value: i64) -> Result<()> {
         acheck!(snd_mixer_selem_set_capture_volume(self.handle, channel as i32, value as c_long)).map(|_| ())
+    }
+
+    pub fn set_capture_volume_range(&self, min: i64, max: i64) -> Result<()> {
+        acheck!(snd_mixer_selem_set_capture_volume_range(self.handle, min as c_long, max as c_long)).map(|_| ())
     }
 
     pub fn set_playback_switch(&self, channel: SelemChannelId, value: i32) -> Result<()> {


### PR DESCRIPTION
I wanted to be able to use consistent values for getting and setting volume, which I discovered can be done by setting the range for these. So I implemented snd_mixer_selem_set_playback_volume_range and snd_mixer_selem_set_capture_volume_range for Selem.