### PR TITLE
Add functions to pcm::Format to get various attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,11 @@ impl $name {
         Self::all().iter().find(|&&x| c == x as ::libc::c_int).map(|&x| x)
             .ok_or_else(|| Error::unsupported(s))
     }
+
+    #[allow(dead_code)]
+    fn to_c_int(&self) -> ::libc::c_int {
+        return *self as ::libc::c_int;
+    }
 }
 
 }

--- a/src/pcm.rs
+++ b/src/pcm.rs
@@ -573,6 +573,22 @@ impl Format {
 
     #[cfg(target_endian = "little")] pub const fn iec958_subframe() -> Format { Format::IEC958SubframeLE }
     #[cfg(target_endian = "big")] pub const fn iec958_subframe() -> Format { Format::IEC958SubframeBE }
+
+    pub fn physical_width(&self) -> Result<i32> {
+        acheck!(snd_pcm_format_physical_width(self.to_c_int()))
+    }
+
+    pub fn width(&self) -> Result<i32> {
+        acheck!(snd_pcm_format_width(self.to_c_int()))
+    }
+
+    pub fn silence_16(&self) -> u16 {
+        unsafe { alsa::snd_pcm_format_silence_16(self.to_c_int()) }
+    }
+
+    pub fn little_endian(&self) -> Result<bool> {
+        acheck!(snd_pcm_format_little_endian(self.to_c_int())).map(|v| v != 0)
+    }
 }
 
 


### PR DESCRIPTION
I tried to do this in a similar way to existing code. I just did the functions I needed; if you would prefer to have all format functions from https://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m___helpers.html implemented at once I can look at doing that.