### PR TITLE
Add methods useful for device/subdevice listing

### DIFF
--- a/examples/enumerate.rs
+++ b/examples/enumerate.rs
@@ -1,0 +1,68 @@
+//! Example that enumerates hardware and PCM devices.
+
+use alsa::Card;
+use alsa::card::Iter;
+use alsa::device_name::HintIter;
+use alsa::ctl::{Ctl, DeviceIter};
+use alsa::{Direction, Error};
+
+// Each card can have multiple devices and subdevices, list them all
+fn list_devices_for_card(card: &Card, direction: Direction) -> Result<(), Error>{
+    // Get a Ctl for the card
+    let ctl_id = format!("hw:{}", card.get_index());
+    let ctl = Ctl::new(&ctl_id, false)?;
+
+    // Read card id and name
+    let cardinfo = ctl.card_info()?;
+    let card_id = cardinfo.get_id()?;
+    let card_name = cardinfo.get_name()?;
+    for device in DeviceIter::new(&ctl) {
+        // Read info from Ctl
+        let pcm_info = ctl.pcm_info(device as u32, 0, direction)?;
+
+        // Read PCM name
+        let pcm_name = pcm_info.get_name()?.to_string();
+
+        println!("card: {:<2} id: {:<10} device: {:<2} card name: '{}' PCM name: '{}'", card.get_index(), card_id, device, card_name, pcm_name);
+
+        // Loop through subdevices and get their names
+        let subdevs = pcm_info.get_subdevices_count();
+        for subdev in 0..subdevs {
+            // Get subdevice name 
+            let pcm_info = ctl.pcm_info(device as u32, subdev, direction)?;
+            let subdev_name = pcm_info.get_subdevice_name()?;
+
+            println!("  subdevice: {:<2} name: '{}'", subdev, subdev_name);
+        }
+    }
+
+
+    Ok(())
+}
+
+pub fn list_hw_devices(direction: Direction) {
+    let cards = Iter::new();
+    cards.for_each(|card| if let Ok(c) = card { list_devices_for_card(&c, direction).unwrap_or_default() });
+}
+
+pub fn list_pcm_devices(direction: Direction) {
+    let hints = HintIter::new_str(None, "pcm").unwrap();
+    for hint in hints {
+        // When Direction is None it means that both the PCM supports both playback and capture
+        if hint.name.is_some() && hint.desc.is_some() && (hint.direction.is_none() || hint.direction.map(|dir| dir == direction).unwrap_or_default()) {
+            println!("name: {:<35} desc: {:?}", hint.name.unwrap(), hint.desc.unwrap());
+        }
+    }
+}
+
+fn main() {
+    println!("\n--- Hardware playback devices ---");
+    list_hw_devices(Direction::Playback);
+    println!("\n--- Hardware capture devices ---");
+    list_hw_devices(Direction::Capture);
+
+    println!("\n--- PCM playback devices ---");
+    list_pcm_devices(Direction::Playback);
+    println!("\n--- PCM capture devices ---");
+    list_pcm_devices(Direction::Capture);
+}

--- a/src/ctl_int.rs
+++ b/src/ctl_int.rs
@@ -43,6 +43,13 @@ impl Ctl {
     pub fn card_info(&self) -> Result<CardInfo> { CardInfo::new().and_then(|c|
         acheck!(snd_ctl_card_info(self.0, c.0)).map(|_| c)) }
 
+    /// Wrapper around [snd_ctl_pcm_next_device](https://www.alsa-project.org/alsa-doc/alsa-lib/control_8c.html#accbb0be6e5ca7361ffec0ea304ed1b05).
+    pub fn pcm_next_device(&self, device: i32) -> Result<i32> {
+        let mut device: c_int = device as c_int;
+        acheck!(snd_ctl_pcm_next_device(self.0, &mut device as *mut _))
+            .map(|_| device)
+    }
+
     pub fn wait(&self, timeout_ms: Option<u32>) -> Result<bool> {
         acheck!(snd_ctl_wait(self.0, timeout_ms.map(|x| x as c_int).unwrap_or(-1))).map(|i| i == 1) }
 

--- a/src/ctl_int.rs
+++ b/src/ctl_int.rs
@@ -2,6 +2,7 @@
 use crate::alsa;
 use super::pcm::Info;
 use std::ffi::{CStr, CString};
+use super::Direction;
 use super::error::*;
 use super::mixer::MilliBel;
 use super::Round;
@@ -93,8 +94,13 @@ impl Ctl {
         acheck!(snd_ctl_read(self.0, e.0)).map(|r| if r == 1 { Some(e) } else { None })
     }
 
-    pub fn info(&self, info: &mut Info) -> Result<()> {
-        acheck!(snd_ctl_pcm_info(self.0, info.0)).map(|_| ())
+    pub fn pcm_info(&self, device: u32, subdevice: u32, direction: Direction) -> Result<Info> {
+        Info::new().and_then(|mut info| {
+            info.set_device(device);
+            info.set_subdevice(subdevice);
+            info.set_stream(direction);
+            acheck!(snd_ctl_pcm_info(self.0, info.0)).map(|_| info )
+        })
     }
 }
 

--- a/src/ctl_int.rs
+++ b/src/ctl_int.rs
@@ -1,5 +1,6 @@
 
 use crate::alsa;
+use super::pcm::Info;
 use std::ffi::{CStr, CString};
 use super::error::*;
 use super::mixer::MilliBel;
@@ -90,6 +91,10 @@ impl Ctl {
     pub fn read(&self) -> Result<Option<Event>> {
         let e = event_new()?;
         acheck!(snd_ctl_read(self.0, e.0)).map(|r| if r == 1 { Some(e) } else { None })
+    }
+
+    pub fn info(&self, info: &mut Info) -> Result<()> {
+        acheck!(snd_ctl_pcm_info(self.0, info.0)).map(|_| ())
     }
 }
 

--- a/src/ctl_int.rs
+++ b/src/ctl_int.rs
@@ -19,6 +19,28 @@ const ELEM_ID_SIZE: usize = 64;
 // const ELEM_VALUE_SIZE: usize = 1224;
 // const ELEM_INFO_SIZE: usize = 272;
 
+
+/// Iterate over devices of a card.
+pub struct DeviceIter(*mut alsa::snd_ctl_t, c_int);
+
+impl DeviceIter {
+    pub(crate) fn new(ctl: *mut alsa::snd_ctl_t) -> DeviceIter {
+        DeviceIter(ctl, -1)
+    }
+}
+
+impl Iterator for DeviceIter {
+    type Item = c_int;
+
+    fn next(&mut self) -> Option<c_int> {
+        match acheck!(snd_ctl_pcm_next_device(self.0, &mut self.1)) {
+            Ok(_) if self.1 == -1 => None,
+            Ok(_) => Some(self.1),
+            Err(_) => None,
+        }
+    }
+}
+
 /// [snd_ctl_t](http://www.alsa-project.org/alsa-doc/alsa-lib/group___control.html) wrapper
 pub struct Ctl(*mut alsa::snd_ctl_t);
 
@@ -46,10 +68,8 @@ impl Ctl {
         acheck!(snd_ctl_card_info(self.0, c.0)).map(|_| c)) }
 
     /// Wrapper around [snd_ctl_pcm_next_device](https://www.alsa-project.org/alsa-doc/alsa-lib/control_8c.html#accbb0be6e5ca7361ffec0ea304ed1b05).
-    pub fn pcm_next_device(&self, device: i32) -> Result<i32> {
-        let mut device: c_int = device as c_int;
-        acheck!(snd_ctl_pcm_next_device(self.0, &mut device as *mut _))
-            .map(|_| device)
+    pub fn pcm_next_device(&self) -> DeviceIter {
+        DeviceIter::new(self.0)
     }
 
     pub fn wait(&self, timeout_ms: Option<u32>) -> Result<bool> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub use crate::card::Card as Card;
 mod ctl_int;
 pub mod ctl {
     //! Control device API
-    pub use super::ctl_int::{Ctl, CardInfo, ElemIface, ElemId, ElemType, ElemValue, ElemInfo};
+    pub use super::ctl_int::{Ctl, CardInfo, DeviceIter, ElemIface, ElemId, ElemType, ElemValue, ElemInfo};
 }
 
 pub use crate::ctl::Ctl as Ctl;

--- a/src/pcm.rs
+++ b/src/pcm.rs
@@ -285,6 +285,10 @@ impl PCM {
             acheck!(snd_pcm_info(self.0, info.0)).map(|_| info ))
     }
 
+    pub fn update_info(&self, info: Info) -> Result<()> {
+        acheck!(snd_pcm_info(self.0, info.0)).map(|_| ())
+    }
+
     pub fn dump(&self, o: &mut Output) -> Result<()> {
         acheck!(snd_pcm_dump(self.0, super::io::output_handle(o))).map(|_| ())
     }

--- a/src/pcm.rs
+++ b/src/pcm.rs
@@ -59,7 +59,7 @@ pub use super::chmap::{Chmap, ChmapPosition, ChmapType, ChmapsQuery};
 /// [snd_pcm_sframes_t](http://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m.html)
 pub type Frames = alsa::snd_pcm_sframes_t;
 
-pub struct Info(pub *mut alsa::snd_pcm_info_t);
+pub struct Info(pub(crate) *mut alsa::snd_pcm_info_t);
 
 impl Info {
     pub fn new() -> Result<Info> {

--- a/src/pcm.rs
+++ b/src/pcm.rs
@@ -59,7 +59,7 @@ pub use super::chmap::{Chmap, ChmapPosition, ChmapType, ChmapsQuery};
 /// [snd_pcm_sframes_t](http://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m.html)
 pub type Frames = alsa::snd_pcm_sframes_t;
 
-pub struct Info(*mut alsa::snd_pcm_info_t);
+pub struct Info(pub *mut alsa::snd_pcm_info_t);
 
 impl Info {
     pub fn new() -> Result<Info> {
@@ -283,10 +283,6 @@ impl PCM {
     pub fn info(&self) -> Result<Info> {
         Info::new().and_then(|info|
             acheck!(snd_pcm_info(self.0, info.0)).map(|_| info ))
-    }
-
-    pub fn update_info(&self, info: &mut Info) -> Result<()> {
-        acheck!(snd_pcm_info(self.0, info.0)).map(|_| ())
     }
 
     pub fn dump(&self, o: &mut Output) -> Result<()> {

--- a/src/pcm.rs
+++ b/src/pcm.rs
@@ -101,6 +101,30 @@ impl Info {
             n @ _ => panic!("snd_pcm_info_get_stream invalid direction '{}'", n),
         }
     }
+
+    pub fn get_subdevices_count(&self) -> u32 {
+        unsafe { alsa::snd_pcm_info_get_subdevices_count(self.0) }
+    }
+
+    pub fn get_subdevices_avail(&self) -> u32 {
+        unsafe { alsa::snd_pcm_info_get_subdevices_avail(self.0) }
+    }
+
+    pub fn set_device(&mut self, device: u32) {
+        unsafe { alsa::snd_pcm_info_set_device(self.0, device) }
+    }
+
+    pub fn set_stream(&mut self, direction: Direction) {
+        let stream = match direction {
+            Direction::Capture => alsa::SND_PCM_STREAM_CAPTURE,
+            Direction::Playback => alsa::SND_PCM_STREAM_PLAYBACK,
+        };
+        unsafe { alsa::snd_pcm_info_set_stream(self.0, stream) }
+    }
+
+    pub fn set_subdevice(&mut self, subdevice: u32) {
+        unsafe { alsa::snd_pcm_info_set_subdevice(self.0, subdevice) }
+    }
 }
 
 impl Drop for Info {

--- a/src/pcm.rs
+++ b/src/pcm.rs
@@ -59,6 +59,7 @@ pub use super::chmap::{Chmap, ChmapPosition, ChmapType, ChmapsQuery};
 /// [snd_pcm_sframes_t](http://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m.html)
 pub type Frames = alsa::snd_pcm_sframes_t;
 
+/// [snd_pcm_info_t](http://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m.html) wrapper - PCM generic info container
 pub struct Info(pub(crate) *mut alsa::snd_pcm_info_t);
 
 impl Info {
@@ -110,11 +111,11 @@ impl Info {
         unsafe { alsa::snd_pcm_info_get_subdevices_avail(self.0) }
     }
 
-    pub fn set_device(&mut self, device: u32) {
+    pub(crate) fn set_device(&mut self, device: u32) {
         unsafe { alsa::snd_pcm_info_set_device(self.0, device) }
     }
 
-    pub fn set_stream(&mut self, direction: Direction) {
+    pub(crate) fn set_stream(&mut self, direction: Direction) {
         let stream = match direction {
             Direction::Capture => alsa::SND_PCM_STREAM_CAPTURE,
             Direction::Playback => alsa::SND_PCM_STREAM_PLAYBACK,
@@ -122,7 +123,7 @@ impl Info {
         unsafe { alsa::snd_pcm_info_set_stream(self.0, stream) }
     }
 
-    pub fn set_subdevice(&mut self, subdevice: u32) {
+    pub(crate) fn set_subdevice(&mut self, subdevice: u32) {
         unsafe { alsa::snd_pcm_info_set_subdevice(self.0, subdevice) }
     }
 }

--- a/src/pcm.rs
+++ b/src/pcm.rs
@@ -285,7 +285,7 @@ impl PCM {
             acheck!(snd_pcm_info(self.0, info.0)).map(|_| info ))
     }
 
-    pub fn update_info(&self, info: Info) -> Result<()> {
+    pub fn update_info(&self, info: &mut Info) -> Result<()> {
         acheck!(snd_pcm_info(self.0, info.0)).map(|_| ())
     }
 


### PR DESCRIPTION
This PR adds a couple of methods that make it easier to list hardware devices and their subdevices.
The additional methods on the `Info` wrapper make it possible to prepare it in order to get it updated via the new `info` method on the `Ctl`. 
Additionally, the new `pcm_next_device` on `Ctl` is needed to get the device numbers for a card. 
