### PR TITLE
Allow to build against bitflags 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["README.md", "LICENSE-*", "Cargo.toml", "src/"]
 [dependencies]
 libc = "0.2"
 alsa-sys = "0.3.1"
-bitflags = "1.3.2"
+bitflags = ">=1.3.2,<3"
 nix = { version = "^0.24", default-features = false, features = ["ioctl"] }
 
 [badges]


### PR DESCRIPTION
Using bitflags 2.0 requires no changes, so it's fine to use 1.3.2 or newer 2.x versions.

Fixes: #103