### PR TITLE
Update nix to 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = ["README.md", "LICENSE-*", "Cargo.toml", "src/"]
 libc = "0.2"
 alsa-sys = "0.3.1"
 bitflags = "2.4.0"
-nix = { version = "^0.26", default-features = false, features = ["ioctl"] }
+nix = { version = "^0.27", default-features = false, features = ["ioctl"] }
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "diwic/alsa-rs" }


### PR DESCRIPTION
Bump up nix to 0.27 to resolve compile issues for new targets (LoongArch/RISC-V).