### PR TITLE
Nuke nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ include = ["README.md", "LICENSE-*", "Cargo.toml", "src/"]
 libc = "0.2"
 alsa-sys = "0.3.1"
 bitflags = "2.4.0"
-nix = { version = "^0.27", default-features = false, features = ["ioctl"] }
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "diwic/alsa-rs" }

--- a/src/direct/ffi.rs
+++ b/src/direct/ffi.rs
@@ -1,10 +1,10 @@
+//! Some definitions from the kernel headers
 
-// Some definitions from the kernel headers
+#![allow(non_camel_case_types)]
 
 // const SNDRV_PCM_MMAP_OFFSET_DATA: c_uint = 0x00000000;
 pub const SNDRV_PCM_MMAP_OFFSET_STATUS: libc::c_uint = 0x80000000;
 pub const SNDRV_PCM_MMAP_OFFSET_CONTROL: libc::c_uint = 0x81000000;
-
 
 pub const SNDRV_PCM_SYNC_PTR_HWSYNC: libc::c_uint = 1;
 pub const SNDRV_PCM_SYNC_PTR_APPL: libc::c_uint = 2;
@@ -25,54 +25,175 @@ pub type __kernel_off_t = libc::c_long;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct snd_pcm_mmap_status {
-	pub state: snd_pcm_state_t,		/* RO: state - SNDRV_PCM_STATE_XXXX */
-	pub pad1: libc::c_int,			/* Needed for 64 bit alignment */
-	pub hw_ptr: snd_pcm_uframes_t,	/* RO: hw ptr (0...boundary-1) */
-	pub tstamp: libc::timespec,		/* Timestamp */
-	pub suspended_state: snd_pcm_state_t, /* RO: suspended stream state */
-	pub audio_tstamp: libc::timespec,	/* from sample counter or wall clock */
+    pub state: snd_pcm_state_t,    /* RO: state - SNDRV_PCM_STATE_XXXX */
+    pub pad1: libc::c_int,         /* Needed for 64 bit alignment */
+    pub hw_ptr: snd_pcm_uframes_t, /* RO: hw ptr (0...boundary-1) */
+    pub tstamp: libc::timespec,    /* Timestamp */
+    pub suspended_state: snd_pcm_state_t, /* RO: suspended stream state */
+    pub audio_tstamp: libc::timespec, /* from sample counter or wall clock */
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct snd_pcm_mmap_control {
-	pub appl_ptr: snd_pcm_uframes_t,	/* RW: appl ptr (0...boundary-1) */
-	pub avail_min: snd_pcm_uframes_t,	/* RW: min available frames for wakeup */
+    pub appl_ptr: snd_pcm_uframes_t,  /* RW: appl ptr (0...boundary-1) */
+    pub avail_min: snd_pcm_uframes_t, /* RW: min available frames for wakeup */
 }
 
 #[repr(C)]
 #[derive(Debug)]
 pub struct snd_pcm_channel_info {
-	pub channel: libc::c_uint,
-	pub offset: __kernel_off_t,		/* mmap offset */
-	pub first: libc::c_uint,		/* offset to first sample in bits */
-	pub step: libc::c_uint, 		/* samples distance in bits */
+    pub channel: libc::c_uint,
+    pub offset: __kernel_off_t, /* mmap offset */
+    pub first: libc::c_uint,    /* offset to first sample in bits */
+    pub step: libc::c_uint,     /* samples distance in bits */
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union snd_pcm_mmap_status_r {
-	pub status: snd_pcm_mmap_status,
-	pub reserved: [libc::c_uchar; 64],
+    pub status: snd_pcm_mmap_status,
+    pub reserved: [libc::c_uchar; 64],
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union snd_pcm_mmap_control_r {
-	pub control: snd_pcm_mmap_control,
-	pub reserved: [libc::c_uchar; 64],
+    pub control: snd_pcm_mmap_control,
+    pub reserved: [libc::c_uchar; 64],
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct snd_pcm_sync_ptr {
-	pub flags: libc::c_uint,
-	pub s: snd_pcm_mmap_status_r,
-	pub c: snd_pcm_mmap_control_r,
+    pub flags: libc::c_uint,
+    pub s: snd_pcm_mmap_status_r,
+    pub c: snd_pcm_mmap_control_r,
 }
 
-ioctl_read!(sndrv_pcm_ioctl_channel_info, b'A', 0x32, snd_pcm_channel_info);
-ioctl_readwrite!(sndrv_pcm_ioctl_sync_ptr, b'A', 0x23, snd_pcm_sync_ptr);
+/// See <https://github.com/nix-rust/nix/blob/197f55b3ccbce3273bf6ce119d1a8541b5df5d66/src/sys/ioctl/linux.rs>
+#[cfg(any(target_os = "linux", target_os = "android"))]
+mod ioctl_helpers {
+    #[cfg(any(target_os = "android", target_env = "musl"))]
+    pub(super) type ioctl_num_type = libc::c_int;
+    #[cfg(not(any(target_os = "android", target_env = "musl")))]
+    pub(super) type ioctl_num_type = libc::c_ulong;
+
+    pub(super) const READ: ioctl_num_type = 2;
+    #[cfg(not(any(
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6",
+        target_arch = "powerpc",
+        target_arch = "powerpc64",
+        target_arch = "sparc64"
+    )))]
+    pub(super) const WRITE: ioctl_num_type = 1;
+    #[cfg(any(
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6",
+        target_arch = "powerpc",
+        target_arch = "powerpc64",
+        target_arch = "sparc64"
+    ))]
+    pub(super) const WRITE: ioctl_num_type = 4;
+
+    const NRSHIFT: ioctl_num_type = 0;
+    const TYPESHIFT: ioctl_num_type = NRSHIFT + 8 /* NRBITS */;
+    const SIZESHIFT: ioctl_num_type = TYPESHIFT + 8 /* TYPEBITS */;
+    const DIRSHIFT: ioctl_num_type = SIZESHIFT + 13 /* SIZEBITS */;
+
+    /// Replication of the [`nix::ioc!`](https://github.com/nix-rust/nix/blob/197f55b3ccbce3273bf6ce119d1a8541b5df5d66/src/sys/ioctl/linux.rs#L78-L96)
+    pub(super) const fn make_request(
+        dir: ioctl_num_type,
+        typ: u8,
+        nr: u8,
+        size: usize,
+    ) -> ioctl_num_type {
+        dir << DIRSHIFT
+            | (typ as ioctl_num_type) << TYPESHIFT
+            | (nr as ioctl_num_type) << NRSHIFT
+            | (size as ioctl_num_type) << SIZESHIFT
+    }
+}
+
+/// See <https://github.com/nix-rust/nix/blob/197f55b3ccbce3273bf6ce119d1a8541b5df5d66/src/sys/ioctl/bsd.rs>
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "solaris",
+    target_os = "illumos"
+))]
+mod ioctl_helpers {
+    #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+    pub(super) type ioctl_num_type = libc::c_ulong;
+    #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+    pub(super) type ioctl_num_type = libc::c_int;
+
+    #[allow(overflowing_literals)]
+    pub(super) const READ: ioctl_num_type = 0x4000_0000;
+    #[allow(overflowing_literals)]
+    pub(super) const WRITE: ioctl_num_type = 0x8000_0000;
+
+    const IOCPARM_MASK: ioctl_num_type = 0x1fff;
+
+    /// Replication of [`nix::ioc!`](https://github.com/nix-rust/nix/blob/197f55b3ccbce3273bf6ce119d1a8541b5df5d66/src/sys/ioctl/bsd.rs#L31-L42)
+    pub(super) const fn make_request(
+        dir: ioctl_num_type,
+        typ: u8,
+        nr: u8,
+        size: usize,
+    ) -> ioctl_num_type {
+        dir | ((size as ioctl_num_type) & IOCPARM_MASK) << 16
+            | (typ as ioctl_num_type) << 8
+            | nr as ioctl_num_type
+    }
+}
+
+pub(crate) unsafe fn sndrv_pcm_ioctl_channel_info(
+    fd: libc::c_int,
+    data: *mut snd_pcm_channel_info,
+) -> Result<(), crate::Error> {
+    const REQUEST: ioctl_helpers::ioctl_num_type = ioctl_helpers::make_request(
+        ioctl_helpers::READ,
+        b'A',
+        0x32,
+        std::mem::size_of::<snd_pcm_channel_info>(),
+    );
+
+    unsafe {
+        if libc::ioctl(fd, REQUEST, data) == -1 {
+            Err(crate::Error::last("SNDRV_PCM_IOCTL_CHANNEL_INFO"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub(crate) unsafe fn sndrv_pcm_ioctl_sync_ptr(
+    fd: libc::c_int,
+    data: *mut snd_pcm_sync_ptr,
+) -> Result<(), crate::Error> {
+    const REQUEST: ioctl_helpers::ioctl_num_type = ioctl_helpers::make_request(
+        ioctl_helpers::READ | ioctl_helpers::WRITE,
+        b'A',
+        0x23,
+        std::mem::size_of::<snd_pcm_sync_ptr>(),
+    );
+
+    unsafe {
+        if libc::ioctl(fd, REQUEST, data) == -1 {
+            Err(crate::Error::last("SNDRV_PCM_IOCTL_SYNC_PTR"))
+        } else {
+            Ok(())
+        }
+    }
+}
 
 pub fn pagesize() -> usize {
     unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }

--- a/src/direct/pcm.rs
+++ b/src/direct/pcm.rs
@@ -54,8 +54,7 @@ impl SyncPtrStatus {
 			s: mem::zeroed()
 		};
 
-        sndrv_pcm_ioctl_sync_ptr(fd, &mut data).map_err(|_|
-            Error::new("SNDRV_PCM_IOCTL_SYNC_PTR", nix::errno::Errno::last() as i32))?;
+        sndrv_pcm_ioctl_sync_ptr(fd, &mut data)?;
 
         let i = data.s.status.state;
         if (i >= (pcm::State::Open as snd_pcm_state_t)) && (i <= (pcm::State::Disconnected as snd_pcm_state_t)) {
@@ -218,7 +217,7 @@ impl<S> DriverMemory<S> {
         let flags = if writable { libc::PROT_WRITE | libc::PROT_READ } else { libc::PROT_READ };
         let p = unsafe { libc::mmap(ptr::null_mut(), total, flags, libc::MAP_FILE | libc::MAP_SHARED, fd, offs) };
         if p.is_null() || p == libc::MAP_FAILED {
-            Err(Error::new("mmap (of driver memory)", nix::errno::Errno::last() as i32))
+            Err(Error::last("mmap (of driver memory)"))
         } else {
             Ok(DriverMemory { ptr: p as *mut S, size: total })
         }
@@ -253,8 +252,7 @@ impl<S> SampleData<S> {
         let fd = pcm_to_fd(p)?;
         let info = unsafe {
             let mut info: snd_pcm_channel_info = mem::zeroed();
-            sndrv_pcm_ioctl_channel_info(fd, &mut info).map_err(|_|
-                Error::new("SNDRV_PCM_IOCTL_CHANNEL_INFO", nix::errno::Errno::last() as i32))?;
+            sndrv_pcm_ioctl_channel_info(fd, &mut info)?;
             info
         };
         // println!("{:?}", info);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
 #![macro_use]
 
-use libc::{c_void, c_int, c_char, free};
-use std::{fmt, str};
-use std::ffi::CStr;
+use libc::{c_char, c_int, c_void, free};
 use std::error::Error as StdError;
+use std::ffi::CStr;
+use std::{fmt, str};
 
 /// ALSA error
 ///
@@ -11,8 +11,8 @@ use std::error::Error as StdError;
 /// If so, then that error code is wrapped into this `Error` struct.
 /// An Error is also returned in case ALSA returns a string that
 /// cannot be translated into Rust's UTF-8 strings.
-#[derive(Debug, Clone, PartialEq, Copy)]
-pub struct Error(&'static str, nix::Error);
+#[derive(Clone, PartialEq, Copy)]
+pub struct Error(&'static str, i32);
 
 pub type Result<T> = ::std::result::Result<T, Error>;
 
@@ -25,76 +25,196 @@ macro_rules! acheck {
 }
 
 pub fn from_const<'a>(func: &'static str, s: *const c_char) -> Result<&'a str> {
-    if s.is_null() { return Err(invalid_str(func)) };
+    if s.is_null() {
+        return Err(invalid_str(func));
+    };
     let cc = unsafe { CStr::from_ptr(s) };
     str::from_utf8(cc.to_bytes()).map_err(|_| invalid_str(func))
 }
 
 pub fn from_alloc(func: &'static str, s: *mut c_char) -> Result<String> {
-    if s.is_null() { return Err(invalid_str(func)) };
+    if s.is_null() {
+        return Err(invalid_str(func));
+    };
     let c = unsafe { CStr::from_ptr(s) };
-    let ss = str::from_utf8(c.to_bytes()).map_err(|_| {
-        unsafe { free(s as *mut c_void); }
-        invalid_str(func)
-    })?.to_string();
-    unsafe { free(s as *mut c_void); }
+    let ss = str::from_utf8(c.to_bytes())
+        .map_err(|_| {
+            unsafe {
+                free(s as *mut c_void);
+            }
+            invalid_str(func)
+        })?
+        .to_string();
+    unsafe {
+        free(s as *mut c_void);
+    }
     Ok(ss)
 }
 
 pub fn from_code(func: &'static str, r: c_int) -> Result<c_int> {
-    if r < 0 { Err(Error::new(func, r)) }
-    else { Ok(r) }
+    if r < 0 {
+        Err(Error::new(func, r))
+    } else {
+        Ok(r)
+    }
 }
 
 impl Error {
     pub fn new(func: &'static str, res: c_int) -> Error {
-        let errno = nix::errno::Errno::from_i32(res as i32);
-        Error(func, errno)
+        Self(func, res)
+    }
+
+    pub fn last(func: &'static str) -> Error {
+        Self(
+            func,
+            std::io::Error::last_os_error()
+                .raw_os_error()
+                .unwrap_or_default(),
+        )
     }
 
     pub fn unsupported(func: &'static str) -> Error {
-        Error(func, nix::Error::ENOTSUP)
+        Error(func, libc::ENOTSUP)
     }
 
     /// The function which failed.
-    pub fn func(&self) -> &'static str { self.0 }
-
-
-    /// Underlying error
-    ///
-    /// Match this against the re-export of `nix::Error` in this crate, not against a specific version
-    /// of the nix crate. The nix crate version might be updated with minor updates of this library.
-    pub fn errno(&self) -> nix::Error { self.1 }
+    pub fn func(&self) -> &'static str {
+        self.0
+    }
 
     /// Underlying error
     ///
     /// Match this against the re-export of `nix::Error` in this crate, not against a specific version
     /// of the nix crate. The nix crate version might be updated with minor updates of this library.
-    pub fn nix_error(&self) -> nix::Error { self.1 }
+    pub fn errno(&self) -> i32 {
+        self.1
+    }
 }
 
-pub fn invalid_str(func: &'static str) -> Error { Error(func, nix::Error::EILSEQ) }
+pub fn invalid_str(func: &'static str) -> Error {
+    Error(func, libc::EILSEQ)
+}
 
 impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> { Some(&self.1) }
-    fn description(&self) -> &str { "ALSA error" }
+    fn description(&self) -> &str {
+        "ALSA error"
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ALSA function '{}' failed with error '{}'", self.0, self.1)
+        write!(
+            f,
+            "ALSA function '{}' failed with error '{} ({})'",
+            self.0,
+            desc(self.1),
+            self.1,
+        )
+    }
+}
+
+/// See <https://github.com/nix-rust/nix/blob/197f55b3ccbce3273bf6ce119d1a8541b5df5d66/src/errno.rs#L198>
+///
+/// Note this doesn't include the total set of possible errno variants, but they
+/// can easily be added in the future for better error messages
+fn desc(errno: i32) -> &'static str {
+    match errno {
+        libc::EPERM => "Operation not permitted",
+        libc::ENOENT => "No such file or directory",
+        libc::ESRCH => "No such process",
+        libc::EINTR => "Interrupted system call",
+        libc::EIO => "I/O error",
+        libc::ENXIO => "No such device or address",
+        libc::E2BIG => "Argument list too long",
+        libc::ENOEXEC => "Exec format error",
+        libc::EBADF => "Bad file number",
+        libc::ECHILD => "No child processes",
+        libc::EAGAIN => "Try again",
+        libc::ENOMEM => "Out of memory",
+        libc::EACCES => "Permission denied",
+        libc::EFAULT => "Bad address",
+        libc::ENOTBLK => "Block device required",
+        libc::EBUSY => "Device or resource busy",
+        libc::EEXIST => "File exists",
+        libc::EXDEV => "Cross-device link",
+        libc::ENODEV => "No such device",
+        libc::ENOTDIR => "Not a directory",
+        libc::EISDIR => "Is a directory",
+        libc::EINVAL => "Invalid argument",
+        libc::ENFILE => "File table overflow",
+        libc::EMFILE => "Too many open files",
+        libc::ENOTTY => "Not a typewriter",
+        libc::ETXTBSY => "Text file busy",
+        libc::EFBIG => "File too large",
+        libc::ENOSPC => "No space left on device",
+        libc::ESPIPE => "Illegal seek",
+        libc::EROFS => "Read-only file system",
+        libc::EMLINK => "Too many links",
+        libc::EPIPE => "Broken pipe",
+        libc::EDOM => "Math argument out of domain of func",
+        libc::ERANGE => "Math result not representable",
+        libc::EDEADLK => "Resource deadlock would occur",
+        libc::ENAMETOOLONG => "File name too long",
+        libc::ENOLCK => "No record locks available",
+        libc::ENOSYS => "Function not implemented",
+        libc::ENOTEMPTY => "Directory not empty",
+        libc::ELOOP => "Too many symbolic links encountered",
+        libc::ENOMSG => "No message of desired type",
+        libc::EIDRM => "Identifier removed",
+        libc::EINPROGRESS => "Operation now in progress",
+        libc::EALREADY => "Operation already in progress",
+        libc::ENOTSOCK => "Socket operation on non-socket",
+        libc::EDESTADDRREQ => "Destination address required",
+        libc::EMSGSIZE => "Message too long",
+        libc::EPROTOTYPE => "Protocol wrong type for socket",
+        libc::ENOPROTOOPT => "Protocol not available",
+        libc::EPROTONOSUPPORT => "Protocol not supported",
+        libc::ESOCKTNOSUPPORT => "Socket type not supported",
+        libc::EPFNOSUPPORT => "Protocol family not supported",
+        libc::EAFNOSUPPORT => "Address family not supported by protocol",
+        libc::EADDRINUSE => "Address already in use",
+        libc::EADDRNOTAVAIL => "Cannot assign requested address",
+        libc::ENETDOWN => "Network is down",
+        libc::ENETUNREACH => "Network is unreachable",
+        libc::ENETRESET => "Network dropped connection because of reset",
+        libc::ECONNABORTED => "Software caused connection abort",
+        libc::ECONNRESET => "Connection reset by peer",
+        libc::ENOBUFS => "No buffer space available",
+        libc::EISCONN => "Transport endpoint is already connected",
+        libc::ENOTCONN => "Transport endpoint is not connected",
+        libc::ESHUTDOWN => "Cannot send after transport endpoint shutdown",
+        libc::ETOOMANYREFS => "Too many references: cannot splice",
+        libc::ETIMEDOUT => "Connection timed out",
+        libc::ECONNREFUSED => "Connection refused",
+        libc::EHOSTDOWN => "Host is down",
+        libc::EHOSTUNREACH => "No route to host",
+        libc::ENOTSUP => "Operation not supported",
+        _ => "Unknown errno",
     }
 }
 
 impl From<Error> for fmt::Error {
-    fn from(_: Error) -> fmt::Error { fmt::Error }
+    fn from(_: Error) -> fmt::Error {
+        fmt::Error
+    }
 }
-
 
 #[test]
 fn broken_pcm_name() {
     use std::ffi::CString;
-    let e = crate::PCM::open(&*CString::new("this_PCM_does_not_exist").unwrap(), crate::Direction::Playback, false).err().unwrap();
+    let e = crate::PCM::open(
+        &*CString::new("this_PCM_does_not_exist").unwrap(),
+        crate::Direction::Playback,
+        false,
+    )
+    .err()
+    .unwrap();
     assert_eq!(e.func(), "snd_pcm_open");
-    assert_eq!(e.errno(), nix::errno::Errno::ENOENT);
+    assert_eq!(e.errno(), libc::ENOENT);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,6 @@ extern crate alsa_sys as alsa;
 extern crate libc;
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate nix as nix_the_crate;
 
 macro_rules! alsa_enum {
  ($(#[$attr:meta])+ $name:ident, $static_name:ident [$count:expr], $( $a:ident = $b:ident),* ,) =>
@@ -133,13 +131,3 @@ pub use crate::io::Output;
 mod chmap;
 
 pub mod direct;
-
-/// Re-exports from the nix crate.
-///
-/// Use these re-exports instead of also depending on the nix crate. There
-/// is no guarantee that these will match a specific nix version, it may
-/// change between minor updates of the library.
-pub mod nix {
-    pub use nix_the_crate::Error;
-    pub use nix_the_crate::errno;
-}

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -6,7 +6,7 @@ use crate::alsa;
 use super::{Direction, poll};
 use std::{ptr, fmt, mem, slice, time, cell};
 use std::str::{FromStr, Split};
-use std::ffi::{CStr};
+use std::ffi::CStr;
 use std::borrow::Cow;
 
 // Workaround for improper alignment of snd_seq_ev_ext_t in alsa-sys
@@ -1318,7 +1318,7 @@ impl RemoveEvents {
     pub fn set_queue(&self, value: i32) { unsafe { alsa::snd_seq_remove_events_set_queue(self.0, value as c_int) } }
     pub fn set_time(&self, value: time::Duration) { unsafe {
         let mut d: alsa::snd_seq_timestamp_t = mem::zeroed();
-        let mut t = &mut d.time;
+        let t = &mut d.time;
 
         t.tv_sec = value.as_secs() as c_uint;
         t.tv_nsec = value.subsec_nanos() as c_uint;


### PR DESCRIPTION
I noticed https://github.com/diwic/alsa-rs/pull/114#issuecomment-1769809723 when I was looking to see why the 0.8.1 version of this crate is using an older version of nix so figured removing nix would be fine. This crate has constantly been using slightly older versions of nix from other dependencies we use, and when I went to replace the use of nix found that the usage was incredibly minimal.

I only tested on linux and had the same test failures as before this change so don't think I broke anything, but I wasn't sure what the intended support for BSD-like targets is since this crate doesn't seem to state anything about them or have CI for them, but I did add support for them, though I failed to figure out to actually get eg. freebsd to build via cross.