### PR TITLE
Fix ioctl bug on linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ include = ["README.md", "LICENSE-*", "Cargo.toml", "src/"]
 libc = "0.2"
 alsa-sys = "0.3.1"
 bitflags = "2.4.0"
+cfg-if = "1.0"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "diwic/alsa-rs" }


### PR DESCRIPTION
There was an off-by-one error (13 instead of 14) for the SIZEBITS value that caused the ioctl code to be screwed up. 

Resolves: #118 