### PR TITLE
Add missing chmap positions

### DIFF
--- a/src/chmap.rs
+++ b/src/chmap.rs
@@ -14,7 +14,7 @@ alsa_enum!(
 
 alsa_enum!(
     /// [SND_CHMAP_xxx](http://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m.html) constants
-    ChmapPosition, ALL_CHMAP_POSITIONS[33],
+    ChmapPosition, ALL_CHMAP_POSITIONS[37],
 
     Unknown = SND_CHMAP_UNKNOWN,
     NA = SND_CHMAP_NA,
@@ -22,6 +22,10 @@ alsa_enum!(
     FL = SND_CHMAP_FL,
     FR = SND_CHMAP_FR,
     RL = SND_CHMAP_RL,
+    RR = SND_CHMAP_RR,
+    FC = SND_CHMAP_FC,
+    LFE = SND_CHMAP_LFE,
+    SL = SND_CHMAP_SL,
     SR = SND_CHMAP_SR,
     RC = SND_CHMAP_RC,
     FLC = SND_CHMAP_FLC,


### PR DESCRIPTION
These four positions were missing in the rust definition of the enum. No idea why. However, that made it impossible to construct any standard surround channel map (which need rear-right (4.0 onward), LFE (2.1 onward), front-center (5.0 onward), or side-left (7.1 onward)).