### PR TITLE
Fix Memory leak in alsa::pcm::PCM::open (?)

### DIFF
--- a/src/pcm.rs
+++ b/src/pcm.rs
@@ -340,7 +340,10 @@ impl PCM {
 }
 
 impl Drop for PCM {
-    fn drop(&mut self) { unsafe { alsa::snd_pcm_close(self.0) }; }
+    fn drop(&mut self) { unsafe {
+        alsa::snd_pcm_close(self.0);
+        alsa::snd_config_update_free_global();
+    }; }
 }
 
 


### PR DESCRIPTION
This PR attempts to fix https://github.com/diwic/alsa-rs/issues/128.

It does so by calling `alsa::snd_config_update_free_global();`. 

I am no alsa expert, so here is some more info on the topic:

* https://alsa-project.org/alsa-doc/alsa-lib/group___config.html#ga51dbc0ff1d9b34d753706d09d768116b
*  https://github.com/alsa-project/alsa-lib/blob/master/MEMORY-LEAK: `"The biggest reported leak is that the global configuration is cached for next usage."` 


Maybe there is a better place to free the global configuration, if caching it for successive usage is of interest?

## System 

I am using alsa `1.2.11`, on Ubuntu 24.04  6.8.0-48-generic.

```
dpkg -l | grep libasound2
ii  libasound2-data                                1.2.11-1build2                           all          Configuration files and profiles for ALSA drivers
ii  libasound2-dev:amd64                           1.2.11-1build2                           amd64        shared library for ALSA applications -- development files
ii  libasound2-plugins:amd64                       1.2.7.1-1ubuntu5                         amd64        ALSA library additional plugins
ii  libasound2t64:amd64                            1.2.11-1build2                           amd64        shared library for ALSA applications
```


## Test

To test this PR I have created a minimal example:

```rs
use alsa::pcm::*;
use alsa::Direction;

fn main() {
    let _ = PCM::new("default", Direction::Capture, false).unwrap();
    // PCM::drop is called
}
```
And ran it as follows:

```bash
cargo build --release --example minimal && valgrind -s --leak-check=full  ./target/release/examples/minimal
```

### Before applying this PR: 

```
==1453338==
==1453338== LEAK SUMMARY:
==1453338==    definitely lost: 1,560 bytes in 22 blocks
==1453338==    indirectly lost: 1,670 bytes in 12 blocks
==1453338==      possibly lost: 76,900 bytes in 2,360 blocks
==1453338==    still reachable: 37,113 bytes in 68 blocks
==1453338==         suppressed: 0 bytes in 0 blocks
==1453338== Reachable blocks (those to which a pointer was found) are not shown.
==1453338== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==1453338==
==1453338== ERROR SUMMARY: 114 errors from 114 contexts (suppressed: 0 from 0)
```

### After applying this PR

```
==1454406==
==1454406== LEAK SUMMARY:
==1454406==    definitely lost: 18,185 bytes in 24 blocks
==1454406==    indirectly lost: 2,226 bytes in 21 blocks
==1454406==      possibly lost: 0 bytes in 0 blocks
==1454406==    still reachable: 16,224 bytes in 43 blocks
==1454406==         suppressed: 0 bytes in 0 blocks
==1454406== Reachable blocks (those to which a pointer was found) are not shown.
==1454406== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==1454406==
==1454406== ERROR SUMMARY: 11 errors from 11 contexts (suppressed: 0 from 0)
```

## Leftover leaks

As you can see, some leaks still remain. And in fact, **definitely lost** has increased.

This is what valgrind has to say: 

```
==1454406== 17,172 (16,616 direct, 556 indirect) bytes in 1 blocks are definitely lost in loss record 38 of 38
==1454406==    at 0x484D953: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1454406==    by 0x5159CE8: ???
==1454406==    by 0x5174096: ???
==1454406==    by 0x515A818: ???
==1454406==    by 0x50BA67B: ???
==1454406==    by 0x48CB6CD: ??? (in /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0)
==1454406==    by 0x48CBD6D: ??? (in /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0)
==1454406==    by 0x48FB37E: snd_pcm_open (in /usr/lib/x86_64-linux-gnu/libasound.so.2.0.0)
==1454406==    by 0x11C796: alsa::pcm::PCM::new (in /home/drusk/alsa-rs-pr/target/release/examples/minimal)
==1454406==    by 0x11C5C2: minimal::main (in /home/drusk/alsa-rs-pr/target/release/examples/minimal)
==1454406==    by 0x11C582: std::sys::backtrace::__rust_begin_short_backtrace (in /home/drusk/alsa-rs-pr/target/release/examples/minimal)
==1454406==    by 0x11C578: std::rt::lang_start::{{closure}} (in /home/drusk/alsa-rs-pr/target/release/examples/minimal)
```

I found this issue, referencing something similar, pointing to a possible leak in libpulse.so.0.21.1.
 
https://github.com/alsa-project/alsa-lib/issues/93

It seems like it does not happen on every system though, I haven't been able to test different versions of alsa, might get around to it at some point.
