### PR TITLE
fix(pcm): htstamp segfaults on 32-bit time64 platforms 

### DIFF
--- a/src/pcm.rs
+++ b/src/pcm.rs
@@ -47,7 +47,7 @@ use libc::{c_int, c_uint, c_void, ssize_t, c_short, timespec, pollfd};
 use crate::alsa;
 use core::convert::Infallible;
 use core::marker::PhantomData;
-use core::mem::{size_of, zeroed};
+use core::mem::size_of;
 use core::ffi::CStr;
 use core::str::FromStr;
 use ::alloc::ffi::CString;
@@ -1271,21 +1271,27 @@ impl Status {
     fn ptr(&self) -> *mut alsa::snd_pcm_status_t { self.0.as_ptr() as *const _ as *mut alsa::snd_pcm_status_t }
 
     pub fn get_htstamp(&self) -> timespec {
-        let mut h: timespec = unsafe { zeroed() };
-        unsafe { alsa::snd_pcm_status_get_htstamp(self.ptr(), &mut h) };
-        h
+        let mut buf = [0u8; 16];
+        unsafe {
+            alsa::snd_pcm_status_get_htstamp(self.ptr(), buf.as_mut_ptr() as *mut timespec);
+            std::ptr::read_unaligned(buf.as_ptr() as *const timespec)
+        }
     }
 
     pub fn get_trigger_htstamp(&self) -> timespec {
-        let mut h: timespec = unsafe { zeroed() };
-        unsafe { alsa::snd_pcm_status_get_trigger_htstamp(self.ptr(), &mut h) };
-        h
+        let mut buf = [0u8; 16];
+        unsafe {
+            alsa::snd_pcm_status_get_trigger_htstamp(self.ptr(), buf.as_mut_ptr() as *mut timespec);
+            std::ptr::read_unaligned(buf.as_ptr() as *const timespec)
+        }
     }
 
     pub fn get_audio_htstamp(&self) -> timespec {
-        let mut h: timespec = unsafe { zeroed() };
-        unsafe { alsa::snd_pcm_status_get_audio_htstamp(self.ptr(), &mut h) };
-        h
+        let mut buf = [0u8; 16];
+        unsafe {
+            alsa::snd_pcm_status_get_audio_htstamp(self.ptr(), buf.as_mut_ptr() as *mut timespec);
+            std::ptr::read_unaligned(buf.as_ptr() as *const timespec)
+        }
     }
 
     pub fn get_state(&self) -> State { State::from_c_int(

--- a/src/pcm.rs
+++ b/src/pcm.rs
@@ -47,7 +47,7 @@ use libc::{c_int, c_uint, c_void, ssize_t, c_short, timespec, pollfd};
 use crate::alsa;
 use core::convert::Infallible;
 use core::marker::PhantomData;
-use core::mem::size_of;
+use core::mem::{size_of, zeroed};
 use core::ffi::CStr;
 use core::str::FromStr;
 use ::alloc::ffi::CString;
@@ -1258,6 +1258,18 @@ impl<'a> fmt::Debug for SwParams<'a> {
 
 const STATUS_SIZE: usize = 152;
 
+#[cfg(target_pointer_width = "32")]
+unsafe fn timespec_from_htstamp_buf(buf: &[u8; 16]) -> timespec {
+    let tv_sec = ptr::read_unaligned(buf.as_ptr() as *const i64) as libc::time_t;
+    // glibc on big-endian places the padding before tv_nsec (offset 12).
+    // Other libc and glibc on little-endian use offset 8.
+    #[cfg(all(target_env = "gnu", target_endian = "big"))]
+    let tv_nsec = ptr::read_unaligned(buf.as_ptr().add(12) as *const libc::c_long);
+    #[cfg(not(all(target_env = "gnu", target_endian = "big")))]
+    let tv_nsec = ptr::read_unaligned(buf.as_ptr().add(8) as *const libc::c_long);
+    timespec { tv_sec, tv_nsec }
+}
+
 /// [snd_pcm_status_t](http://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m___status.html) wrapper
 #[derive(Debug)]
 pub struct Status([u64; (STATUS_SIZE+7)/8]);
@@ -1271,26 +1283,53 @@ impl Status {
     fn ptr(&self) -> *mut alsa::snd_pcm_status_t { self.0.as_ptr() as *const _ as *mut alsa::snd_pcm_status_t }
 
     pub fn get_htstamp(&self) -> timespec {
-        let mut buf = [0u8; 16];
-        unsafe {
-            alsa::snd_pcm_status_get_htstamp(self.ptr(), buf.as_mut_ptr() as *mut timespec);
-            std::ptr::read_unaligned(buf.as_ptr() as *const timespec)
+        #[cfg(not(target_pointer_width = "32"))]
+        {
+            let mut h: timespec = unsafe { zeroed() };
+            unsafe { alsa::snd_pcm_status_get_htstamp(self.ptr(), &mut h) };
+            h
+        }
+        #[cfg(target_pointer_width = "32")]
+        {
+            let mut buf = [0u8; 16];
+            unsafe {
+                alsa::snd_pcm_status_get_htstamp(self.ptr(), buf.as_mut_ptr() as *mut timespec);
+                timespec_from_htstamp_buf(&buf)
+            }
         }
     }
 
     pub fn get_trigger_htstamp(&self) -> timespec {
-        let mut buf = [0u8; 16];
-        unsafe {
-            alsa::snd_pcm_status_get_trigger_htstamp(self.ptr(), buf.as_mut_ptr() as *mut timespec);
-            std::ptr::read_unaligned(buf.as_ptr() as *const timespec)
+        #[cfg(not(target_pointer_width = "32"))]
+        {
+            let mut h: timespec = unsafe { zeroed() };
+            unsafe { alsa::snd_pcm_status_get_trigger_htstamp(self.ptr(), &mut h) };
+            h
+        }
+        #[cfg(target_pointer_width = "32")]
+        {
+            let mut buf = [0u8; 16];
+            unsafe {
+                alsa::snd_pcm_status_get_trigger_htstamp(self.ptr(), buf.as_mut_ptr() as *mut timespec);
+                timespec_from_htstamp_buf(&buf)
+            }
         }
     }
 
     pub fn get_audio_htstamp(&self) -> timespec {
-        let mut buf = [0u8; 16];
-        unsafe {
-            alsa::snd_pcm_status_get_audio_htstamp(self.ptr(), buf.as_mut_ptr() as *mut timespec);
-            std::ptr::read_unaligned(buf.as_ptr() as *const timespec)
+        #[cfg(not(target_pointer_width = "32"))]
+        {
+            let mut h: timespec = unsafe { zeroed() };
+            unsafe { alsa::snd_pcm_status_get_audio_htstamp(self.ptr(), &mut h) };
+            h
+        }
+        #[cfg(target_pointer_width = "32")]
+        {
+            let mut buf = [0u8; 16];
+            unsafe {
+                alsa::snd_pcm_status_get_audio_htstamp(self.ptr(), buf.as_mut_ptr() as *mut timespec);
+                timespec_from_htstamp_buf(&buf)
+            }
         }
     }
 


### PR DESCRIPTION
This popped up downstream in RustAudio/cpal#1134 and fixes #150 without the need to set `RUST_LIBC_UNSTABLE_GNU_TIME_BITS=64`.

On 32-bit Linux with a `time64` glibc, `snd_pcm_status_get_htstamp` and friends write a 16-byte struct `timespec` into the pointer passed to them. Since `libc::timespec` is only 8 bytes on these targets, the alsa function then wrote 8 bytes past it, corrupting the stack and causing a segfault. This PR passes a 16-byte buffer on 32-bit targets to reconstruct a `timespec` from it.

I don't have a big-endian system to test with, but I made it endianness-aware from what I could gather. `glibc`'s `time64` seems to place a 4-byte padding before `tv_nsec` on big-endian and after it on little-endian, so `tv_nsec` sits at offset 8 on LE and offset 12 on BE. Other `libc`s seem to use offset 8 regardless of endianness, hence the `target_env = "gnu"` guard.

On 64-bit targets, `libc::timespec` is already 16 bytes, so the original `zeroed()` + direct call is left untouched.

**One limitation, likely significant:** 32-bit systems with a `time32` `alsa-lib` were never affected by the segfault, but will now regress to have `tv_nsec` silently read as zero. While the `time64` transition is effectively done on modern distros, this is almost a case of "pick your poison": segfault on 32-bit targets with `time64` _or_ return zero `tv_nsec` on 32-bit targets.

I say _almost_ because it probably can be fixed using a `build.rs` probe of `sizeof(time_t)` in C to set a `cfg` flag. I wasn't sure whether that's worth the added complexity here, so leaving it to your judgement.